### PR TITLE
Add scenario engine with websocket integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Consciousness profiles use comprehensive JSON schema:
 - **Resources**: Attention, emotional energy, processing capacity
 - **Debug Hooks**: Player intervention points and debugging capabilities
 
+### Scenario Engine
+
+The `ScenarioEngine` loads JSON files from `data/scenarios/` and tracks player
+progress across branching debugging challenges. It listens to
+`consciousness-engine` events and emits real-time updates over WebSockets.
+
+```javascript
+import { consciousnessEngine } from './lib/websocket-handlers.js';
+import ScenarioEngine from './lib/scenario-engine.js';
+
+const scenarioEngine = new ScenarioEngine();
+await scenarioEngine.initialize();
+scenarioEngine.attach(consciousnessEngine);
+```
+
 ## 🛠️ Development
 
 ### Prerequisites

--- a/data/scenarios/scenario_1_park_memory.json
+++ b/data/scenarios/scenario_1_park_memory.json
@@ -1,0 +1,31 @@
+{
+  "id": "scenario_1_park_memory",
+  "title": "The Day Everything Changed",
+  "conditions": {
+    "triggers": ["action === 'peek' && result.success"],
+    "prerequisites": []
+  },
+  "modifications": {
+    "processes": [
+      { "name": "park_memory_replay.exe", "action": "start", "parameters": {} }
+    ],
+    "resources": {},
+    "errors": []
+  },
+  "objectives": [
+    {
+      "id": "break_memory_loop",
+      "success_conditions": {
+        "loopBroken": "state.processes.running <= 5"
+      }
+    }
+  ],
+  "interventions": [],
+  "narrative": {
+    "intro": ["Memories of the park surge into focus, overwhelming the system."],
+    "outcomes": {
+      "success": "The loop releases its grip, freeing Alexander to move forward.",
+      "failure": "Temporal lock intensifies, scattering consciousness across timelines."
+    }
+  }
+}

--- a/lib/scenario-engine.js
+++ b/lib/scenario-engine.js
@@ -1,0 +1,210 @@
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import path from 'path';
+import { EventEmitter } from 'events';
+
+/**
+ * ScenarioEngine
+ * Loads scenario definitions and manages progression.
+ * Scenarios are defined as JSON files under data/scenarios.
+ */
+export default class ScenarioEngine extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.scenarioDir = options.scenarioDir || path.join(process.cwd(), 'data', 'scenarios');
+    this.watchFiles = options.watch ?? false;
+    this.scenarios = new Map(); // id -> scenario definition
+    this.progress = new Map();  // characterId -> {scenarioId -> progress}
+    this.watcher = null;
+    this.engine = null; // attached ConsciousnessEngine
+  }
+
+  /** Initialize engine and optionally start file watcher */
+  async initialize() {
+    await this.loadAll();
+    if (this.watchFiles) {
+      this.startWatcher();
+    }
+    this.emit('initialized', { count: this.scenarios.size });
+  }
+
+  /** Attach to a ConsciousnessEngine instance */
+  attach(consciousnessEngine) {
+    this.engine = consciousnessEngine;
+    this.engine.on('actionExecuted', (data) => this.handleAction(data));
+    this.engine.on('stateUpdate', (data) => this.handleStateUpdate(data));
+  }
+
+  /** Load all scenario files from directory */
+  async loadAll() {
+    this.scenarios.clear();
+    try {
+      const files = await fs.readdir(this.scenarioDir);
+      for (const file of files) {
+        if (file.endsWith('.json')) {
+          const full = path.join(this.scenarioDir, file);
+          const scenario = await this.loadFile(full);
+          this.scenarios.set(scenario.id, scenario);
+        }
+      }
+    } catch (err) {
+      this.emit('error', { type: 'load', error: err });
+    }
+  }
+
+  /** Load a single scenario file */
+  async loadFile(filePath) {
+    const data = await fs.readFile(filePath, 'utf8');
+    const scenario = JSON.parse(data);
+    return scenario;
+  }
+
+  /** Reload a specific file when changed */
+  async reloadFile(filename) {
+    try {
+      const filePath = path.join(this.scenarioDir, filename);
+      const scenario = await this.loadFile(filePath);
+      this.scenarios.set(scenario.id, scenario);
+      this.emit('reloaded', { id: scenario.id });
+    } catch (err) {
+      this.emit('error', { type: 'reload', error: err });
+    }
+  }
+
+  /** Start file watcher in development */
+  startWatcher() {
+    if (this.watcher) return;
+    this.watcher = fsSync.watch(this.scenarioDir, (event, filename) => {
+      if (filename && filename.endsWith('.json')) {
+        this.reloadFile(filename);
+      }
+    });
+  }
+
+  /** Handle player actions */
+  async handleAction({ characterId, action, result, state }) {
+    const instance = this.engine?.instances.get(characterId);
+    if (!instance) return;
+    await this.evaluate(characterId, instance.getState(), action, result);
+  }
+
+  /** Handle state updates */
+  async handleStateUpdate({ characterId, state }) {
+    const instance = this.engine?.instances.get(characterId);
+    if (!instance) return;
+    await this.evaluate(characterId, state);
+  }
+
+  /** Evaluate scenarios for a character */
+  async evaluate(characterId, state, action = null, result = null) {
+    for (const scenario of this.scenarios.values()) {
+      const progress = this.getScenarioProgress(characterId, scenario.id);
+      if (progress.status === 'complete') continue;
+
+      // Check prerequisites
+      if (!this.checkConditions(scenario.conditions?.prerequisites || [], state, action, result)) {
+        continue;
+      }
+
+      if (progress.status !== 'active') {
+        // Check triggers to start scenario
+        if (this.checkConditions(scenario.conditions?.triggers || [], state, action, result)) {
+          await this.startScenario(characterId, scenario);
+        }
+      } else {
+        // Scenario active - check objectives for completion
+        if (this.checkObjectives(scenario.objectives || [], state)) {
+          await this.completeScenario(characterId, scenario, 'success');
+        }
+      }
+    }
+  }
+
+  /** Simple condition evaluation using Function constructor */
+  checkConditions(conditions, state, action, result) {
+    if (conditions.length === 0) return true;
+    return conditions.every(cond => {
+      try {
+        const fn = new Function('state', 'action', 'result', `return (${cond});`);
+        return !!fn(state, action, result);
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /** Basic objective check */
+  checkObjectives(objectives, state) {
+    if (objectives.length === 0) return false;
+    return objectives.every(obj => this.checkConditions(obj.success_conditions ? Object.values(obj.success_conditions) : [], state));
+  }
+
+  /** Begin scenario and apply modifications */
+  async startScenario(characterId, scenario) {
+    const instance = this.engine?.instances.get(characterId);
+    if (!instance) return;
+
+    const mod = scenario.modifications || {};
+    if (mod.processes) {
+      for (const p of mod.processes) {
+        try {
+          await instance.modifyProcess(p.name, p.action, p.parameters || {});
+        } catch {}
+      }
+    }
+    // Other modifications (resources/errors) could be handled here
+
+    const progress = this.getScenarioProgress(characterId, scenario.id);
+    progress.status = 'active';
+    progress.startTime = Date.now();
+    this.saveProgress(characterId);
+    this.emit('scenarioStarted', { characterId, scenario });
+  }
+
+  /** Mark scenario complete */
+  async completeScenario(characterId, scenario, outcome = 'success') {
+    const progress = this.getScenarioProgress(characterId, scenario.id);
+    progress.status = 'complete';
+    progress.outcome = outcome;
+    progress.endTime = Date.now();
+    this.saveProgress(characterId);
+    this.emit('scenarioCompleted', { characterId, scenarioId: scenario.id, outcome });
+  }
+
+  /** Get or create progress for scenario */
+  getScenarioProgress(characterId, scenarioId) {
+    if (!this.progress.has(characterId)) {
+      this.progress.set(characterId, {});
+    }
+    const charProg = this.progress.get(characterId);
+    if (!charProg[scenarioId]) {
+      charProg[scenarioId] = { status: 'pending', choices: [] };
+    }
+    return charProg[scenarioId];
+  }
+
+  /** Save progress to file */
+  async saveProgress(characterId) {
+    try {
+      const dir = path.join(this.scenarioDir, 'progress');
+      await fs.mkdir(dir, { recursive: true });
+      const file = path.join(dir, `${characterId}.json`);
+      await fs.writeFile(file, JSON.stringify(this.progress.get(characterId), null, 2));
+    } catch (err) {
+      this.emit('error', { type: 'save', error: err });
+    }
+  }
+
+  /** Load progress for character */
+  async loadProgress(characterId) {
+    try {
+      const file = path.join(this.scenarioDir, 'progress', `${characterId}.json`);
+      const data = await fs.readFile(file, 'utf8');
+      const parsed = JSON.parse(data);
+      if (!this.progress.has(characterId)) this.progress.set(characterId, parsed);
+      else Object.assign(this.progress.get(characterId), parsed);
+    } catch {
+      // Ignore if no progress file
+    }
+  }
+}

--- a/lib/websocket-handlers.js
+++ b/lib/websocket-handlers.js
@@ -1,9 +1,13 @@
 import { ConsciousnessEngine } from './consciousness-engine.js';
+import ScenarioEngine from './scenario-engine.js';
 import { info, error } from './logger.js';
 
 
 // Create singleton instance
 const consciousnessEngine = new ConsciousnessEngine();
+const scenarioEngine = new ScenarioEngine({
+  watch: process.env.NODE_ENV !== 'production'
+});
 
 // Track initialization state
 let isEngineInitialized = false;
@@ -12,6 +16,8 @@ let isEngineInitialized = false;
 async function ensureEngineInitialized() {
   if (!isEngineInitialized) {
     await consciousnessEngine.initialize();
+    await scenarioEngine.initialize();
+    scenarioEngine.attach(consciousnessEngine);
     isEngineInitialized = true;
     info('Consciousness engine initialized successfully');
   }
@@ -38,6 +44,14 @@ class WebSocketHandlers {
 
     consciousnessEngine.on('debug-hook-triggered', (data) => {
       this.broadcastDebugHook(data);
+    });
+
+    // Listen for scenario events
+    scenarioEngine.on('scenarioStarted', (data) => {
+      this.broadcastScenarioEvent('scenario-started', data);
+    });
+    scenarioEngine.on('scenarioCompleted', (data) => {
+      this.broadcastScenarioEvent('scenario-completed', data);
     });
   }
 
@@ -340,6 +354,13 @@ class WebSocketHandlers {
       breakpoint: data.breakpoint,
       timestamp: data.timestamp
     });
+  }
+
+  broadcastScenarioEvent(event, data) {
+    if (!this.io) return;
+
+    const room = `character-${data.characterId}`;
+    this.io.to(room).emit(event, data);
   }
 
   // Utility methods


### PR DESCRIPTION
## Summary
- create `lib/scenario-engine.js` for loading and tracking scenarios
- add example scenario in `data/scenarios`
- integrate scenario engine with WebSockets and add broadcasts
- document scenario engine usage in README

## Testing
- `npm install`
- `node tests/quick-test.js`
- `node tests/test-schema.js`


------
https://chatgpt.com/codex/tasks/task_e_685a08bcd3688327a211ccaf9c036d5e