### PR TITLE
Implement debug commands and validation

### DIFF
--- a/lib/consciousness-engine.js
+++ b/lib/consciousness-engine.js
@@ -165,9 +165,22 @@ export class ConsciousnessEngine extends EventEmitter {
       'characters',
       `${characterId}.json`
     );
-    
+
+    try {
+      await fs.access(characterPath);
+    } catch (err) {
+      throw new Error(`Character ${characterId} not found`);
+    }
+
     const data = await fs.readFile(characterPath, 'utf8');
-    return JSON.parse(data);
+    let parsed;
+    try {
+      parsed = JSON.parse(data);
+    } catch (err) {
+      throw new Error(`Failed to parse ${characterId}.json`);
+    }
+
+    return parsed;
   }
 
   /**
@@ -745,5 +758,45 @@ export class ConsciousnessEngine extends EventEmitter {
     });
     
     return errors.sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  /**
+   * Execute a simple debug command on a character
+   */
+  async executeDebugCommand(characterId, command, args = {}) {
+    const instance = this.instances.get(characterId);
+    if (!instance) {
+      throw new Error(`No consciousness loaded: ${characterId}`);
+    }
+
+    const state = instance.getState().consciousness;
+
+    switch (command) {
+      case 'ps':
+        return { processes: instance.processManager.getProcessList() };
+      case 'top':
+        return {
+          processes: instance.processManager.getProcessList().slice(0, 5),
+          resources: state.resources
+        };
+      case 'monitor':
+        return {
+          memory: state.memory,
+          errors: state.system_errors,
+          resources: state.resources
+        };
+      case 'kill':
+        if (args.pid) {
+          try {
+            await instance.processManager.killProcess(args.pid);
+            return { success: true, pid: args.pid, status: 'killed' };
+          } catch (err) {
+            return { error: `Process ${args.pid} not found` };
+          }
+        }
+        return { error: 'PID required for kill command' };
+      default:
+        return { error: `Unknown command: ${command}` };
+    }
   }
 }


### PR DESCRIPTION
## Summary
- validate character data file existence when loading
- add simple debug command handler with process listing and kill support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ad224f2e08327afb868f10d13cd38