### PR TITLE
Fix monitoring to manual refresh

### DIFF
--- a/lib/websocket-handlers.js
+++ b/lib/websocket-handlers.js
@@ -304,6 +304,28 @@ class WebSocketHandlers {
       }
     });
 
+    // Manual refresh of monitoring data
+    socket.on('refresh-monitor', async () => {
+      try {
+        const info = this.connectedSockets.get(socket.id);
+        if (!info || !info.characterId) {
+          socket.emit('error', { message: 'No character being monitored' });
+          return;
+        }
+
+        const state = await consciousnessEngine.getState(info.characterId);
+        socket.emit('consciousness-update', {
+          characterId: info.characterId,
+          state,
+          timestamp: Date.now(),
+          type: 'manual-refresh'
+        });
+      } catch (err) {
+        error('Error handling refresh-monitor', { error: err });
+        socket.emit('error', { message: 'Failed to refresh monitor' });
+      }
+    });
+
     // Emit system resources
     socket.on('get-system-resources', async () => {
       console.log('📊 WEBSOCKET: Received get-system-resources request');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -68,9 +68,7 @@ class App {
         }
         break;
       case 'monitor':
-        if (window.monitor && this.currentCharacter) {
-          window.monitor.startMonitoring();
-        }
+        // Monitoring should only start via explicit user action
         break;
       case 'debugger':
         if (window.debugger) {

--- a/public/js/consciousness.js
+++ b/public/js/consciousness.js
@@ -59,7 +59,7 @@ class ConsciousnessManager {
     if (window.stateManager) {
       window.stateManager.set('monitoringActive', true);
     }
-    this.startRealTimeUpdates();
+    // No auto-update loop; server will send initial data
     if (window.socketClient && window.socketClient.isSocketConnected()) {
       window.socketClient.startMonitoring(this.currentCharacter.id);
     }
@@ -346,11 +346,8 @@ class ConsciousnessManager {
 }
 
   startRealTimeUpdates() {
-    if (this.updateInterval) return;
-    
-    this.updateInterval = setInterval(() => {
-      this.requestConsciousnessUpdate();
-    }, 2000);
+    // Auto-update loop disabled; updates occur on manual refresh
+    return;
   }
 
   stopRealTimeUpdates() {

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -365,11 +365,8 @@ getDebugState() {
     try {
       // Use WebSocket if connected, fallback to API
       if (window.socketClient && window.socketClient.isConnected) {
-        // Request fresh data via WebSocket using the correct method
         console.log('📡 MONITOR: Requesting data via WebSocket');
-        window.socketClient.emitToServer('get-system-resources');
-        window.socketClient.emitToServer('get-error-logs');
-        window.socketClient.emitToServer('get-memory-allocation');
+        window.socketClient.refreshMonitor();
         this.showStatus('Data refresh requested via WebSocket', 'success');
       } else {
         // Fallback to API call

--- a/public/js/socket-client.js
+++ b/public/js/socket-client.js
@@ -20,6 +20,7 @@ class SocketClient {
       'system-resources',
       'error-logs',
       'memory-allocation',
+      'refresh-monitor',
       'connect',
       'disconnect',
       'error'
@@ -191,6 +192,17 @@ class SocketClient {
     this.recordUserInteraction('stop-monitoring');
     
     this.socket.emit('stop-monitoring', { characterId });
+    return true;
+  }
+
+  refreshMonitor() {
+    if (!this.isConnected) {
+      console.error('Socket not connected');
+      return false;
+    }
+
+    this.recordUserInteraction('refresh-monitor');
+    this.socket.emit('refresh-monitor');
     return true;
   }
 

--- a/test-monitor.js
+++ b/test-monitor.js
@@ -18,10 +18,8 @@ socket.on('monitoring-started', (data) => {
     console.log('✓ Monitoring started:', data);
     
     // Test data requests
-    console.log('Testing data requests...');
-    socket.emit('get-system-resources');
-    socket.emit('get-error-logs');
-    socket.emit('get-memory-allocation');
+    console.log('Testing refresh-monitor event...');
+    socket.emit('refresh-monitor');
 });
 
 socket.on('system-resources', (data) => {

--- a/tests/unit/consciousnessManager.test.js
+++ b/tests/unit/consciousnessManager.test.js
@@ -35,7 +35,7 @@ describe('ConsciousnessManager Monitoring Lifecycle', () => {
   it('starts monitoring only after userStartMonitoring()', () => {
     manager.userStartMonitoring();
     expect(manager.isMonitoring).toBe(true);
-    expect(manager.updateInterval).not.toBe(null);
+    expect(manager.updateInterval).toBe(null);
     expect(window.socketClient.startMonitoring).toHaveBeenCalledWith('alexander-kane');
   });
 


### PR DESCRIPTION
## Summary
- remove automatic monitor start when navigating to monitor section
- disable auto-update loops in ConsciousnessManager
- add refresh-monitor helper in SocketClient
- send refresh-monitor request from the monitor UI
- implement refresh-monitor socket event on backend
- update monitor test and unit tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685be92f772083279feb803d29a2537f