### PR TITLE
Refactor consciousness engine modules

### DIFF
--- a/lib/consciousness-engine.js
+++ b/lib/consciousness-engine.js
@@ -1,12 +1,13 @@
-import fs from 'fs/promises';
-import path from 'path';
-import { validate } from 'jsonschema';
 import { EventEmitter } from 'events';
-import { ConsciousnessInstance } from './consciousness-instance.js';
 import { ProcessGenerator } from './process-generator.js';
 import { StateManager } from './state-manager.js';
 import { NarrativeEngine } from './narrative-engine.js';
 import ProcessEvolutionSystem from './ProcessEvolutionSystem.js';
+import { SchemaLoader } from './engine/schema-loader.js';
+import { AutosaveManager } from './engine/autosave-manager.js';
+import { TickLoop } from './engine/tick-loop.js';
+import { CharacterLoader } from './engine/character-loader.js';
+import { MonitorResponder } from './engine/monitor-responder.js';
 
 /**
  * Universal Consciousness Engine
@@ -37,10 +38,14 @@ export class ConsciousnessEngine extends EventEmitter {
     
     // System state
     this.isRunning = false;
-    this.tickInterval = null;
-    this.autosaveInterval = null;
-    this.isInitialized = false;  // Track initialization state
-    this.broadcastInterval = null;  // <-- ADD THIS LINE HERE
+    this.isInitialized = false; // Track initialization state
+
+    // Engine helpers
+    this.schemaLoader = new SchemaLoader(this.schemas);
+    this.autosaveManager = new AutosaveManager(this);
+    this.tickLoop = new TickLoop(this);
+    this.characterLoader = new CharacterLoader(this);
+    this.monitorResponder = new MonitorResponder(this);
   }
 
   /**
@@ -80,80 +85,32 @@ export class ConsciousnessEngine extends EventEmitter {
 
   /**
    * Load JSON schemas for validation
-   */  async loadSchemas() {
-  // Skip if already loaded
-  if (this.schemas.size > 0) {
-    console.log('Schemas already loaded, skipping');
-    return;
+   */
+  async loadSchemas() {
+    return this.schemaLoader.load();
   }
-
-  const schemaDir = path.join(process.cwd(), 'data', 'schema');
-  const schemaFiles = [
-    'consciousness-schema.json',
-    'story-schema.json',
-    'narrative-fragment-schema.json'
-  ];
-
-  console.log(`Loading schemas from: ${schemaDir}`);
-
-  for (const file of schemaFiles) {
-    const schemaPath = path.join(schemaDir, file);
-    try {
-      const schemaData = await fs.readFile(schemaPath, 'utf8');
-      const schema = JSON.parse(schemaData);
-      const schemaKey = file.replace('.json', '');
-      this.schemas.set(schemaKey, schema);
-      console.log(`Loaded schema: ${schemaKey}`);
-    } catch (error) {
-      console.error(`Failed to load schema ${file}:`, error);
-      throw new Error(`Failed to load schema ${file}: ${error.message}`);
-    }
-  }
-  
-  console.log(`Successfully loaded ${this.schemas.size} schemas`);
-}
 
   /**
    * Start the system tick interval
  */
-startSystemTick() {
-  // Prevent multiple tick loops
-  if (this.isRunning || this.tickInterval) {
-    console.log('System tick already running');
-    return;
+  startSystemTick() {
+    if (this.isRunning) return;
+    this.isRunning = true;
+    this.tickLoop.start();
+    this.autosaveManager.start();
   }
-
-  this.isRunning = true;
-  this.tickInterval = setInterval(() => {
-    this.systemTick();
-  }, this.config.tickRate);
-
-  // Start autosave interval only if not already running
-  if (!this.autosaveInterval) {
-    this.autosaveInterval = setInterval(() => {
-      this.autosaveAll();
-    }, this.config.autosaveInterval);
-  }
-  
-  console.log('System tick started');
-}
 
   /**
    * Stop the system tick
    */
   stopSystemTick() {
-    if (this.tickInterval) {
-      clearInterval(this.tickInterval);
-      this.tickInterval = null;
-    }
-    
-    if (this.autosaveInterval) {
-      clearInterval(this.autosaveInterval);
-      this.autosaveInterval = null;
-    }
-    
     this.isRunning = false;
-    console.log('System tick stopped');
+    this.tickLoop.stop();
+    this.autosaveManager.stop();
+  }
+
+  async autosaveAll() {
+    return this.autosaveManager.autosaveAll();
   }
 
 
@@ -161,100 +118,11 @@ startSystemTick() {
    * Load a character consciousness with story context
    */
   async loadCharacter(characterId, options = {}) {
-     // Return existing instance if already loaded
-  if (this.instances.has(characterId)) {
-    console.log(`Character ${characterId} already loaded`);
-    return this.instances.get(characterId);
-  }
-    // Check instance limit
-    if (this.instances.size >= this.config.maxInstances) {
-      throw new Error('Maximum consciousness instances reached');
-    }
-
-    // Load character data
-    const characterData = await this.loadCharacterData(characterId);    
-    // Validate against schema
-    const schema = this.schemas.get('consciousness-schema');
-    if (!schema) {
-      throw new Error('Consciousness schema not loaded. Engine may not be properly initialized.');
-    }
-    
-    const validation = validate(characterData, schema);
-    if (!validation.valid) {
-      throw new Error(`Invalid consciousness data: ${validation.errors.map(e => e.message).join(', ')}`);
-    }
-
-    // Create instance with options
-    const instance = new ConsciousnessInstance({
-      ...characterData,
-      engine: this,
-      dynamicProcessing: options.enableDynamic ?? true,
-      difficultyLevel: options.difficulty ?? 'intermediate',
-      debugMode: options.debugMode ?? this.config.debugMode
-    });
-
-    // Set story context if provided
-    if (options.storyContext) {
-      this.storyContexts.set(characterId, options.storyContext);
-      
-      // Load story-specific narrative fragments
-      await this.narrativeEngine.loadStoryFragments(options.storyContext.storyId);
-    }
-
-    // Initialize with starting state
-    const startingState = options.startingState ?? characterData.defaultState;
-    await instance.initialize(startingState);
-
-    // Store instance
-    this.instances.set(characterId, instance);
-
-    this.emit('characterLoaded', { characterId, instance });
-    console.log(`Character ${characterId} loaded successfully`);
-    
-    return instance;
-
-    // Load previous progress if exists
-    if (options.loadProgress) {
-      const progress = await this.stateManager.loadProgress(
-        options.userId,
-        characterId,
-        options.storyContext?.storyId
-      );
-      if (progress) {
-        await instance.restoreState(progress);
-      }
-    }
-
-    this.emit('characterLoaded', { characterId, instance });
-    return instance;
+    return this.characterLoader.loadCharacter(characterId, options);
   }
 
-  /**
-   * Load character data from file
-   */
   async loadCharacterData(characterId) {
-    const characterPath = path.join(
-      process.cwd(),
-      'data',
-      'characters',
-      `${characterId}.json`
-    );
-
-    try {
-      await fs.access(characterPath);
-    } catch (err) {
-      throw new Error(`Character ${characterId} not found`);
-    }
-
-    const data = await fs.readFile(characterPath, 'utf8');
-    let parsed;
-    try {
-      parsed = JSON.parse(data);
-    } catch (err) {
-      throw new Error(`Failed to parse ${characterId}.json`);
-    }
-
-    return parsed;
+    return this.characterLoader.loadCharacterData(characterId);
   }
 
   /**
@@ -434,43 +302,16 @@ startSystemTick() {
 
   /**
    * Load story configuration
-   */
+  */
   async loadStoryConfig(storyId) {
-    const storyPath = path.join(
-      process.cwd(),
-      'data',
-      'stories',
-      storyId,
-      'story-config.json'
-    );
-    
-    const data = await fs.readFile(storyPath, 'utf8');
-    const config = JSON.parse(data);
-    
-    // Validate against schema
-    const validation = validate(config, this.schemas.get('story-schema'));
-    if (!validation.valid) {
-      throw new Error(`Invalid story configuration: ${validation.errors.map(e => e.message).join(', ')}`);
-    }
-    
-    return config;
+    return this.characterLoader.loadStoryConfig(storyId);
   }
 
   /**
    * Unload a character consciousness
-   */
+  */
   async unloadCharacter(characterId) {
-    const instance = this.instances.get(characterId);
-    if (!instance) return;
-
-    // Save final state
-    await instance.shutdown();
-
-    // Remove from tracking
-    this.instances.delete(characterId);
-    this.storyContexts.delete(characterId);
-
-    this.emit('characterUnloaded', { characterId });
+    return this.characterLoader.unloadCharacter(characterId);
   }
 
   /**
@@ -495,103 +336,10 @@ startSystemTick() {
    * System tick - update all active consciousnesses
    */
   async systemTick() {
-    for (const [characterId, instance] of this.instances) {
-      try {
-        // Update instance
-        const updates = await instance.tick();
-
-        // Apply process evolution rules
-        const gameState = instance.getState();
-        for (const process of instance.processManager.processes.values()) {
-          const evolved = this.processEvolution.evolveProcess(process, gameState);
-          Object.assign(process, evolved);
-        }
-
-        // Spawn emergent processes
-        const emergent = this.processEvolution.checkForEmergentProcesses(gameState);
-        if (emergent.length > 0) {
-          emergent.forEach(p => {
-            instance.processManager.processes.set(p.pid, p);
-          });
-        }
-        
-        // Check for narrative triggers from system state
-        const storyContext = this.storyContexts.get(characterId);
-        if (storyContext && updates.stateChanges.length > 0) {
-          const narrativeEvents = await this.narrativeEngine.checkSystemTriggers(
-            instance.getState(),
-            updates,
-            storyContext
-          );
-          
-          if (narrativeEvents.length > 0) {
-            await this.applyNarrativeEffects(instance, narrativeEvents, storyContext);
-          }
-        }
-
-        // Emit updates for UI
-        if (updates.hasChanges) {
-          this.emit('stateUpdate', {
-            characterId,
-            updates,
-            state: instance.getState()
-          });
-        }
-      } catch (error) {
-        this.emit('tickError', { characterId, error });
-      }
-    }
+    return this.tickLoop.systemTick();
   }
 
-  /**
-   * Start the system tick interval
-   */
-  startSystemTick() {
-    if (this.tickInterval) return;
-    
-    this.isRunning = true;
-    this.tickInterval = setInterval(() => {
-      this.systemTick();
-    }, this.config.tickRate);
 
-    // Start autosave
-    this.autosaveInterval = setInterval(() => {
-      this.autosaveAll();
-    }, this.config.autosaveInterval);
-  }
-
-  /**
-   * Stop the system tick
-   */
-  stopSystemTick() {
-    this.isRunning = false;
-    
-    if (this.tickInterval) {
-      clearInterval(this.tickInterval);
-      this.tickInterval = null;
-    }
-    
-    if (this.autosaveInterval) {
-      clearInterval(this.autosaveInterval);
-      this.autosaveInterval = null;
-    }
-  }
-
-  /**
-   * Autosave all active instances
-   */
-  async autosaveAll() {
-    for (const [characterId, instance] of this.instances) {
-      const storyContext = this.storyContexts.get(characterId);
-      if (storyContext?.userId) {
-        await this.saveProgress(
-          storyContext.userId,
-          characterId,
-          storyContext.storyId
-        );
-      }
-    }
-  }
 
   /**
    * Shutdown the engine
@@ -622,115 +370,27 @@ startSystemTick() {
   /**
    * Start monitoring a character consciousness
    */
-  async startMonitoring(characterId, socketId) {
-    const instance = this.instances.get(characterId);
-    if (!instance) {
-      throw new Error(`No consciousness loaded: ${characterId}`);
-    }
 
-    // Set up monitoring for this socket
-    if (!this.monitoringSockets) {
-      this.monitoringSockets = new Map();
-    }
-    
-    this.monitoringSockets.set(socketId, {
-      characterId,
-      startTime: Date.now(),
-      lastUpdate: Date.now()
-    });
-
-    // Start sending updates to this socket
-    this.emit('monitoringStarted', {
-      characterId,
-      socketId,
-      initialState: instance.getState()
-    });
-
-    return {
-      success: true,
-      message: `Monitoring started for ${characterId}`,
-      characterId,
-      socketId
-    };
-  }
 /**
  * Start real-time broadcasting for active monitoring sockets
  * DISABLED: Only send updates on-demand or when state actually changes
  */
 startRealTimeBroadcasting() {
-  // DISABLED: No automatic polling/broadcasting
-  // Users will request data via refresh button or state changes will trigger updates
-  console.log('📴 Real-time broadcasting disabled - using on-demand updates only');
-  return;
-  
-  // OLD CODE (disabled):
-  // if (this.broadcastInterval) return;
-  // this.broadcastInterval = setInterval(() => {
-  //   this.broadcastToMonitoringSockets();
-  // }, 10000); // Update every 10 seconds
+  this.monitorResponder.startRealTimeBroadcasting();
 }
 
 /**
  * Stop real-time broadcasting
  */
 stopRealTimeBroadcasting() {
-  if (this.broadcastInterval) {
-    clearInterval(this.broadcastInterval);
-    this.broadcastInterval = null;
-  }
+  this.monitorResponder.stopRealTimeBroadcasting();
 }
 
 /**
  * Broadcast consciousness updates to all monitoring sockets
  */
 async broadcastToMonitoringSockets() {
-  if (!this.monitoringSockets || this.monitoringSockets.size === 0) {
-    return;
-  }
-
-  for (const [socketId, monitoring] of this.monitoringSockets) {
-    try {
-      const { characterId } = monitoring;
-      const instance = this.instances.get(characterId);
-      
-      if (!instance) {
-        // Character instance no longer exists, clean up
-        this.monitoringSockets.delete(socketId);
-        continue;
-      }
-
-      // Get current consciousness state
-      const currentState = await this.getState(characterId);
-      
-      // FIXED: Send data in the structure the client expects
-      // The client expects the consciousness data directly, not nested
-      this.emit('consciousnessUpdate', {
-        socketId,
-        characterId,
-        consciousness: {
-          processes: currentState.processes || [],
-          resources: currentState.consciousness?.resources || {
-            cpu: { used: 0, total: 100, percentage: 0 },
-            memory: { used: 0, total: 1024, available: 1024, percentage: 0 },
-            threads: { used: 0, total: 16, percentage: 0 }
-          },
-          system_errors: currentState.system_errors || [],
-          memory: currentState.consciousness?.memory || {},
-          threads: currentState.threads || []
-        },
-        timestamp: Date.now(),
-        type: 'real-time-update'
-      });
-      
-      // Update last update time
-      monitoring.lastUpdate = Date.now();
-      
-    } catch (error) {
-      console.error(`Error broadcasting to socket ${socketId}:`, error);
-      // Remove problematic socket
-      this.monitoringSockets.delete(socketId);
-    }
-  }
+  return this.monitorResponder.broadcastStateChange();
 }
 
 /**
@@ -738,142 +398,21 @@ async broadcastToMonitoringSockets() {
  * This replaces the automatic 10-second polling with event-driven updates
  */
 async broadcastStateChange(characterId, changeType = 'state-change') {
-  if (!this.monitoringSockets || this.monitoringSockets.size === 0) {
-    return;
-  }
-
-  console.log(`📡 Broadcasting state change for ${characterId} (${changeType})`);
-
-  for (const [socketId, monitoring] of this.monitoringSockets) {
-    try {
-      if (monitoring.characterId !== characterId) {
-        continue; // Only broadcast to sockets monitoring this specific character
-      }
-
-      const instance = this.instances.get(characterId);
-      if (!instance) {
-        this.monitoringSockets.delete(socketId);
-        continue;
-      }
-
-      // Get current consciousness state
-      const currentState = await this.getState(characterId);
-      
-      // Send data in the structure the client expects
-      this.emit('consciousnessUpdate', {
-        socketId,
-        characterId,
-        consciousness: {
-          processes: currentState.processes || [],
-          resources: currentState.consciousness?.resources || {
-            cpu: { used: 0, total: 100, percentage: 0 },
-            memory: { used: 0, total: 1024, available: 1024, percentage: 0 },
-            threads: { used: 0, total: 16, percentage: 0 }
-          },
-          system_errors: currentState.system_errors || [],
-          memory: currentState.consciousness?.memory || {},
-          threads: currentState.threads || []
-        },
-        timestamp: Date.now(),
-        type: changeType
-      });
-      
-      monitoring.lastUpdate = Date.now();
-      
-    } catch (error) {
-      console.error(`Error broadcasting state change to socket ${socketId}:`, error);
-      this.monitoringSockets.delete(socketId);
-    }
-  }
+  return this.monitorResponder.broadcastStateChange(characterId, changeType);
 }
 
 /**
  * Enhanced startMonitoring method
  */
 async startMonitoring(characterId, socketId) {
-  const instance = this.instances.get(characterId);
-  if (!instance) {
-    throw new Error(`No consciousness loaded: ${characterId}`);
-  }
-
-  // Set up monitoring for this socket
-  if (!this.monitoringSockets) {
-    this.monitoringSockets = new Map();
-  }
-  
-  this.monitoringSockets.set(socketId, {
-    characterId,
-    startTime: Date.now(),
-    lastUpdate: Date.now()
-  });
-
-  // Start broadcasting if this is the first monitoring socket
-  if (this.monitoringSockets.size === 1) {
-    this.startRealTimeBroadcasting();
-  }
-
-  // Send initial state immediately
-  const initialState = await this.getState(characterId);
-  this.emit('monitoringStarted', {
-    characterId,
-    socketId,
-    initialState: {
-      consciousness: initialState.consciousness,
-      processes: initialState.processes,
-      system_errors: initialState.system_errors,
-      threads: initialState.threads
-    }
-  });
-
-  // Send first real-time update
-  setTimeout(() => {
-    this.emit('consciousnessUpdate', {
-      socketId,
-      characterId,
-      state: {
-        consciousness: initialState.consciousness,
-        processes: initialState.processes,
-        system_errors: initialState.system_errors,
-        threads: initialState.threads
-      },
-      timestamp: Date.now(),
-      type: 'initial-update'
-    });
-  }, 100);
-
-  return {
-    success: true,
-    message: `Monitoring started for ${characterId}`,
-    characterId,
-    socketId
-  };
+  return this.monitorResponder.startMonitoring(characterId, socketId);
 }
 
 /**
  * Enhanced stopMonitoring method
  */
 async stopMonitoring(socketId) {
-  console.log(`Stopping monitoring for socket: ${socketId}`);
-  
-  if (!this.monitoringSockets) return;
-  
-  const monitoring = this.monitoringSockets.get(socketId);
-  if (monitoring) {
-    this.monitoringSockets.delete(socketId);
-    console.log(`Removed socket ${socketId} from monitoring. Remaining sockets: ${this.monitoringSockets.size}`);
-    
-    // Stop broadcasting if no more monitoring sockets
-    if (this.monitoringSockets.size === 0) {
-      console.log('No more monitoring sockets, stopping broadcast interval');
-      this.stopRealTimeBroadcasting();
-    }
-    
-    this.emit('monitoringStopped', {
-      characterId: monitoring.characterId,
-      socketId,
-      duration: Date.now() - monitoring.startTime
-    });
-  }
+  return this.monitorResponder.stopMonitoring(socketId);
 }
 
 /**
@@ -894,8 +433,8 @@ async shutdown() {
   this.instances.clear();
   this.storyContexts.clear();
   
-  if (this.monitoringSockets) {
-    this.monitoringSockets.clear();
+  if (this.monitorResponder.monitoringSockets) {
+    this.monitorResponder.monitoringSockets.clear();
   }
   
   this.emit('shutdown');

--- a/lib/engine/autosave-manager.js
+++ b/lib/engine/autosave-manager.js
@@ -1,0 +1,29 @@
+export class AutosaveManager {
+  constructor(engine) {
+    this.engine = engine;
+    this.interval = null;
+  }
+
+  start() {
+    if (this.interval) return;
+    this.interval = setInterval(() => {
+      this.autosaveAll();
+    }, this.engine.config.autosaveInterval);
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async autosaveAll() {
+    for (const [characterId, instance] of this.engine.instances) {
+      const ctx = this.engine.storyContexts.get(characterId);
+      if (ctx?.userId) {
+        await this.engine.saveProgress(ctx.userId, characterId, ctx.storyId);
+      }
+    }
+  }
+}

--- a/lib/engine/character-loader.js
+++ b/lib/engine/character-loader.js
@@ -1,0 +1,92 @@
+import fs from 'fs/promises';
+import { join } from 'path';
+import { validate } from 'jsonschema';
+import { ConsciousnessInstance } from '../consciousness-instance.js';
+import { resolveDataPath } from './engine-utils.js';
+
+export class CharacterLoader {
+  constructor(engine) {
+    this.engine = engine;
+  }
+
+  async loadCharacter(characterId, options = {}) {
+    if (this.engine.instances.has(characterId)) {
+      console.log(`Character ${characterId} already loaded`);
+      return this.engine.instances.get(characterId);
+    }
+    if (this.engine.instances.size >= this.engine.config.maxInstances) {
+      throw new Error('Maximum consciousness instances reached');
+    }
+    const data = await this.loadCharacterData(characterId);
+    const schema = this.engine.schemas.get('consciousness-schema');
+    if (!schema) {
+      throw new Error('Consciousness schema not loaded. Engine may not be properly initialized.');
+    }
+    const validation = validate(data, schema);
+    if (!validation.valid) {
+      throw new Error(`Invalid consciousness data: ${validation.errors.map(e => e.message).join(', ')}`);
+    }
+    const instance = new ConsciousnessInstance({
+      ...data,
+      engine: this.engine,
+      dynamicProcessing: options.enableDynamic ?? true,
+      difficultyLevel: options.difficulty ?? 'intermediate',
+      debugMode: options.debugMode ?? this.engine.config.debugMode
+    });
+    if (options.storyContext) {
+      this.engine.storyContexts.set(characterId, options.storyContext);
+      await this.engine.narrativeEngine.loadStoryFragments(options.storyContext.storyId);
+    }
+    const startingState = options.startingState ?? data.defaultState;
+    await instance.initialize(startingState);
+    this.engine.instances.set(characterId, instance);
+    this.engine.emit('characterLoaded', { characterId, instance });
+    console.log(`Character ${characterId} loaded successfully`);
+    if (options.loadProgress) {
+      const progress = await this.engine.stateManager.loadProgress(
+        options.userId,
+        characterId,
+        options.storyContext?.storyId
+      );
+      if (progress) {
+        await instance.restoreState(progress);
+      }
+    }
+    return instance;
+  }
+
+  async loadCharacterData(characterId) {
+    const filePath = join(resolveDataPath('characters'), `${characterId}.json`);
+    try {
+      await fs.access(filePath);
+    } catch {
+      throw new Error(`Character ${characterId} not found`);
+    }
+    const data = await fs.readFile(filePath, 'utf8');
+    try {
+      return JSON.parse(data);
+    } catch {
+      throw new Error(`Failed to parse ${characterId}.json`);
+    }
+  }
+
+  async loadStoryConfig(storyId) {
+    const storyPath = join(resolveDataPath('stories', storyId), 'story-config.json');
+    const data = await fs.readFile(storyPath, 'utf8');
+    const config = JSON.parse(data);
+    const validation = validate(config, this.engine.schemas.get('story-schema'));
+    if (!validation.valid) {
+      throw new Error(`Invalid story configuration: ${validation.errors.map(e => e.message).join(', ')}`);
+    }
+    return config;
+  }
+
+  async unloadCharacter(characterId) {
+    const instance = this.engine.instances.get(characterId);
+    if (!instance) return;
+    await instance.shutdown();
+    this.engine.instances.delete(characterId);
+    this.engine.storyContexts.delete(characterId);
+    this.engine.emit('characterUnloaded', { characterId });
+  }
+}

--- a/lib/engine/engine-utils.js
+++ b/lib/engine/engine-utils.js
@@ -1,0 +1,5 @@
+import path from 'path';
+
+export function resolveDataPath(...segments) {
+  return path.join(process.cwd(), 'data', ...segments);
+}

--- a/lib/engine/monitor-responder.js
+++ b/lib/engine/monitor-responder.js
@@ -1,0 +1,110 @@
+export class MonitorResponder {
+  constructor(engine) {
+    this.engine = engine;
+    this.monitoringSockets = new Map();
+    this.broadcastInterval = null;
+  }
+
+  startRealTimeBroadcasting() {
+    console.log('\uD83D\uDD34 Real-time broadcasting disabled - using on-demand updates only');
+    return;
+  }
+
+  stopRealTimeBroadcasting() {
+    if (this.broadcastInterval) {
+      clearInterval(this.broadcastInterval);
+      this.broadcastInterval = null;
+    }
+  }
+
+  async broadcastStateChange(characterId, changeType = 'state-change') {
+    if (this.monitoringSockets.size === 0) return;
+    for (const [socketId, monitoring] of this.monitoringSockets) {
+      if (monitoring.characterId !== characterId) continue;
+      const instance = this.engine.instances.get(characterId);
+      if (!instance) {
+        this.monitoringSockets.delete(socketId);
+        continue;
+      }
+      const state = await this.engine.getState(characterId);
+      this.engine.emit('consciousnessUpdate', {
+        socketId,
+        characterId,
+        consciousness: {
+          processes: state.processes || [],
+          resources: state.consciousness?.resources || {
+            cpu: { used: 0, total: 100, percentage: 0 },
+            memory: { used: 0, total: 1024, available: 1024, percentage: 0 },
+            threads: { used: 0, total: 16, percentage: 0 }
+          },
+          system_errors: state.system_errors || [],
+          memory: state.consciousness?.memory || {},
+          threads: state.threads || []
+        },
+        timestamp: Date.now(),
+        type: changeType
+      });
+      monitoring.lastUpdate = Date.now();
+    }
+  }
+
+  async startMonitoring(characterId, socketId) {
+    const instance = this.engine.instances.get(characterId);
+    if (!instance) {
+      throw new Error(`No consciousness loaded: ${characterId}`);
+    }
+    this.monitoringSockets.set(socketId, {
+      characterId,
+      startTime: Date.now(),
+      lastUpdate: Date.now()
+    });
+    if (this.monitoringSockets.size === 1) {
+      this.startRealTimeBroadcasting();
+    }
+    const initialState = await this.engine.getState(characterId);
+    this.engine.emit('monitoringStarted', {
+      characterId,
+      socketId,
+      initialState: {
+        consciousness: initialState.consciousness,
+        processes: initialState.processes,
+        system_errors: initialState.system_errors,
+        threads: initialState.threads
+      }
+    });
+    setTimeout(() => {
+      this.engine.emit('consciousnessUpdate', {
+        socketId,
+        characterId,
+        state: {
+          consciousness: initialState.consciousness,
+          processes: initialState.processes,
+          system_errors: initialState.system_errors,
+          threads: initialState.threads
+        },
+        timestamp: Date.now(),
+        type: 'initial-update'
+      });
+    }, 100);
+    return {
+      success: true,
+      message: `Monitoring started for ${characterId}`,
+      characterId,
+      socketId
+    };
+  }
+
+  async stopMonitoring(socketId) {
+    if (!this.monitoringSockets.has(socketId)) return;
+    const monitoring = this.monitoringSockets.get(socketId);
+    this.monitoringSockets.delete(socketId);
+    if (this.monitoringSockets.size === 0) {
+      this.stopRealTimeBroadcasting();
+    }
+    this.engine.emit('monitoringStopped', {
+      characterId: monitoring.characterId,
+      socketId,
+      duration: Date.now() - monitoring.startTime
+    });
+  }
+}

--- a/lib/engine/schema-loader.js
+++ b/lib/engine/schema-loader.js
@@ -1,0 +1,41 @@
+import fs from 'fs/promises';
+import { join } from 'path';
+import { resolveDataPath } from './engine-utils.js';
+
+export class SchemaLoader {
+  constructor(schemaMap) {
+    this.schemaMap = schemaMap;
+  }
+
+  async load() {
+    if (this.schemaMap.size > 0) {
+      console.log('Schemas already loaded, skipping');
+      return;
+    }
+
+    const schemaDir = resolveDataPath('schema');
+    const schemaFiles = [
+      'consciousness-schema.json',
+      'story-schema.json',
+      'narrative-fragment-schema.json'
+    ];
+
+    console.log(`Loading schemas from: ${schemaDir}`);
+
+    for (const file of schemaFiles) {
+      const schemaPath = join(schemaDir, file);
+      try {
+        const data = await fs.readFile(schemaPath, 'utf8');
+        const schema = JSON.parse(data);
+        const key = file.replace('.json', '');
+        this.schemaMap.set(key, schema);
+        console.log(`Loaded schema: ${key}`);
+      } catch (err) {
+        console.error(`Failed to load schema ${file}:`, err);
+        throw new Error(`Failed to load schema ${file}: ${err.message}`);
+      }
+    }
+
+    console.log(`Successfully loaded ${this.schemaMap.size} schemas`);
+  }
+}

--- a/lib/engine/tick-loop.js
+++ b/lib/engine/tick-loop.js
@@ -1,0 +1,59 @@
+export class TickLoop {
+  constructor(engine) {
+    this.engine = engine;
+    this.interval = null;
+  }
+
+  start() {
+    if (this.interval) return;
+    this.interval = setInterval(() => {
+      this.systemTick();
+    }, this.engine.config.tickRate);
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async systemTick() {
+    for (const [characterId, instance] of this.engine.instances) {
+      try {
+        const updates = await instance.tick();
+        const gameState = instance.getState();
+        for (const process of instance.processManager.processes.values()) {
+          const evolved = this.engine.processEvolution.evolveProcess(process, gameState);
+          Object.assign(process, evolved);
+        }
+        const emergent = this.engine.processEvolution.checkForEmergentProcesses(gameState);
+        if (emergent.length > 0) {
+          emergent.forEach(p => {
+            instance.processManager.processes.set(p.pid, p);
+          });
+        }
+        const storyContext = this.engine.storyContexts.get(characterId);
+        if (storyContext && updates.stateChanges.length > 0) {
+          const events = await this.engine.narrativeEngine.checkSystemTriggers(
+            instance.getState(),
+            updates,
+            storyContext
+          );
+          if (events.length > 0) {
+            await this.engine.applyNarrativeEffects(instance, events, storyContext);
+          }
+        }
+        if (updates.hasChanges) {
+          this.engine.emit('stateUpdate', {
+            characterId,
+            updates,
+            state: instance.getState()
+          });
+        }
+      } catch (err) {
+        this.engine.emit('tickError', { characterId, error: err });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- split large consciousness engine into modular services
- add schema loader, autosave manager, tick loop, character loader, monitor responder
- wire up new helpers in `consciousness-engine.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf481efa483279e10b84bf136d8b0