### PR TITLE
Refactor instance modules

### DIFF
--- a/lib/consciousness-instance.js
+++ b/lib/consciousness-instance.js
@@ -1,7 +1,11 @@
 import { EventEmitter } from 'events';
 import ProcessManager from './ProcessManager.js';
-import MemoryManager from './MemoryManager.js';
-import EmotionalProcessor from './EmotionalProcessor.js';
+import EmotionalState from './instance/emotional-state.js';
+import MemoryState from './instance/memory-state.js';
+import ActionRouter from './instance/action-router.js';
+import SnapshotManager from './instance/snapshot-manager.js';
+import InstanceEvents from './instance/instance-events.js';
+import * as InstanceUtils from './instance/instance-utils.js';
 
 /**
  * Individual consciousness instance
@@ -40,8 +44,11 @@ export class ConsciousnessInstance extends EventEmitter {
     
     // Subsystems
     this.processManager = new ProcessManager(this);
-    this.memoryManager = new MemoryManager(this, config.memoryMap);
-    this.emotionalProcessor = new EmotionalProcessor(this, config.emotionalStates);
+    this.memoryState = new MemoryState(this, config.memoryMap);
+    this.emotionalState = new EmotionalState(this, config.emotionalStates);
+    this.events = new InstanceEvents(this);
+    this.snapshotManager = new SnapshotManager(this);
+    this.actionRouter = new ActionRouter(this);
     
     // State tracking
     this.state = {
@@ -53,9 +60,6 @@ export class ConsciousnessInstance extends EventEmitter {
       lastUpdate: Date.now()
     };
     
-    // History for rollback
-    this.stateHistory = [];
-    this.maxHistorySize = 10;
     
     // Reference to parent engine
     this.engine = config.engine;
@@ -70,8 +74,8 @@ export class ConsciousnessInstance extends EventEmitter {
       
       // Initialize subsystems
       await this.processManager.initialize(this.config.baseProcesses);
-      await this.memoryManager.initialize();
-      await this.emotionalProcessor.initialize(startingState.emotional);
+      await this.memoryState.initialize();
+      await this.emotionalState.initialize(startingState.emotional);
       
       // Load starting processes
       if (startingState.activeProcesses) {
@@ -83,7 +87,7 @@ export class ConsciousnessInstance extends EventEmitter {
       // Load memory fragments
       if (startingState.memoryFragments) {
         for (const fragment of startingState.memoryFragments) {
-          await this.memoryManager.writeMemory(fragment.address, fragment.content);
+          await this.memoryState.manager.writeMemory(fragment.address, fragment.content);
         }
       }
       
@@ -92,7 +96,7 @@ export class ConsciousnessInstance extends EventEmitter {
       this.state.corruption = startingState.corruption ?? 0.0;
       
       this.state.status = 'running';
-      this.emit('initialized', this.getState());
+      this.events.initialized(this.getState());
       
     } catch (error) {
       this.state.status = 'error';
@@ -109,74 +113,7 @@ export class ConsciousnessInstance extends EventEmitter {
    * Execute a debug action
    */
   async executeAction(action, parameters = {}) {
-    // Validate action
-    if (!this.isValidAction(action)) {
-      throw new Error(`Invalid action: ${action}`);
-    }
-    
-    // Check system stability
-    if (this.state.stability < 0.1 && !parameters.force) {
-      throw new Error('System too unstable for action execution');
-    }
-    
-    // Save state for potential rollback
-    this.saveStateSnapshot();
-    
-    try {
-      let result = {};
-      
-      // Route action to appropriate subsystem
-      switch (this.getActionCategory(action)) {
-        case 'process':
-          result = await this.processManager.executeAction(action, parameters);
-          break;
-          
-        case 'memory':
-          result = await this.memoryManager.executeAction(action, parameters);
-          break;
-          
-        case 'emotional':
-          result = await this.emotionalProcessor.executeAction(action, parameters);
-          break;
-          
-        case 'system':
-          result = await this.executeSystemAction(action, parameters);
-          break;
-          
-        default:
-          throw new Error(`Unknown action category for: ${action}`);
-      }
-      
-      // Update resource usage
-      await this.updateResourceUsage();
-      
-      // Check for system instability
-      this.checkSystemHealth();
-      
-      return {
-        success: true,
-        action,
-        result,
-        state: this.getState(),
-        timestamp: Date.now()
-      };
-      
-    } catch (error) {
-      // Log error
-      this.state.errors.push({
-        timestamp: Date.now(),
-        action,
-        type: 'action_execution',
-        message: error.message
-      });
-      
-      // Potentially trigger error cascade
-      if (this.shouldCascadeError(error)) {
-        await this.triggerErrorCascade(error);
-      }
-      
-      throw error;
-    }
+    return this.actionRouter.execute(action, parameters);
   }
 
   /**
@@ -195,8 +132,8 @@ export class ConsciousnessInstance extends EventEmitter {
     try {
       // Update subsystems
       const processUpdates = await this.processManager.tick();
-      const memoryEvents = await this.memoryManager.tick();
-      const emotionalShifts = await this.emotionalProcessor.tick();
+      const memoryEvents = await this.memoryState.tick();
+      const emotionalShifts = await this.emotionalState.tick();
       
       // Aggregate updates
       updates.processUpdates = processUpdates;
@@ -204,10 +141,10 @@ export class ConsciousnessInstance extends EventEmitter {
       updates.emotionalShifts = emotionalShifts;
       
       // Update resource usage
-      await this.updateResourceUsage();
+      await InstanceUtils.updateResourceUsage(this);
       
       // Calculate stability changes
-      const stabilityDelta = this.calculateStabilityDelta();
+      const stabilityDelta = InstanceUtils.calculateStabilityDelta(this);
       if (Math.abs(stabilityDelta) > 0.001) {
         this.state.stability = Math.max(0, Math.min(1, this.state.stability + stabilityDelta));
         updates.stateChanges.push({
@@ -218,7 +155,7 @@ export class ConsciousnessInstance extends EventEmitter {
       }
       
       // Check for corruption spread
-      const corruptionDelta = this.calculateCorruptionSpread();
+      const corruptionDelta = InstanceUtils.calculateCorruptionSpread(this);
       if (corruptionDelta > 0) {
         this.state.corruption = Math.min(1, this.state.corruption + corruptionDelta);
         updates.stateChanges.push({
@@ -232,7 +169,7 @@ export class ConsciousnessInstance extends EventEmitter {
       this.state.uptime += this.config.tickRate;
       
       // Clean old errors
-      this.cleanErrorLog();
+      InstanceUtils.cleanErrorLog(this);
       
       updates.hasChanges = updates.stateChanges.length > 0 ||
                           updates.processUpdates.length > 0 ||
@@ -255,54 +192,7 @@ export class ConsciousnessInstance extends EventEmitter {
    * Get current consciousness state
    */
   getState() {
-    // Get system resource usage from process manager
-    const systemResources = this.processManager ? this.processManager.getSystemResourceUsage() : {};
-    // Get memory state from memory manager
-    const memoryState = this.memoryManager ? this.memoryManager.getState() : {};
-    const memoryStatus = this.memoryManager ? this.memoryManager.getMemoryStatus() : {};
-
-    // Ensure all resource keys are present
-    const cpu = {
-      used: this.usage.cpu || 0,
-      total: 100,
-      percentage: this.usage.cpu || 0
-    };
-    const memory = {
-      processUsage: systemResources.totalMemoryUsage || 0,
-      processPercentage: systemResources.memoryPercentage || 0,
-      used: memoryStatus.capacity?.used || this.usage.memory || 0,
-      total: memoryStatus.capacity?.total || (this.resources && this.resources.memory ? this.resources.memory.total : 10000),
-      available: memoryStatus.capacity?.available || ((this.resources && this.resources.memory ? this.resources.memory.total : 10000) - (this.usage.memory || 0)),
-      percentage: (() => {
-        if (memoryStatus.capacity && 
-            typeof memoryStatus.capacity.used === 'number' && 
-            typeof memoryStatus.capacity.total === 'number' && 
-            memoryStatus.capacity.total > 0) {
-          const calc = (memoryStatus.capacity.used / memoryStatus.capacity.total) * 100;
-          return isNaN(calc) ? 0 : calc;
-        }
-        const memoryUsed = this.usage.memory || 0;
-        const memoryTotal = (this.resources && this.resources.memory ? this.resources.memory.total : 10000);
-        const calc = (memoryUsed / memoryTotal) * 100;
-        return isNaN(calc) ? 0 : calc;
-      })()
-    };
-    const threads = {
-      used: this.usage.threads || 0,
-      total: (this.resources && this.resources.threads ? this.resources.threads.max : 16),
-      percentage: ((this.usage.threads || 0) / ((this.resources && this.resources.threads ? this.resources.threads.max : 16))) * 100
-    };
-
-    return {
-      consciousness: {
-        processes: this.processManager ? this.processManager.getProcessList() : [],
-        memory: memoryState,
-        resources: { cpu, memory, threads },
-        system_errors: this.state.errors.slice(-5),
-        threads: []
-      },
-      timestamp: Date.now()
-    };
+    return this.snapshotManager.getState();
   }
 
 
@@ -310,14 +200,7 @@ export class ConsciousnessInstance extends EventEmitter {
    * Capture complete state for save/restore
    */
   captureState() {
-    return {
-      core: { ...this.state },
-      resources: { ...this.usage },
-      processes: this.processManager.captureState(),
-      memory: this.memoryManager.captureState(),
-      emotional: this.emotionalProcessor.captureState(),
-      timestamp: Date.now()
-    };
+    return this.snapshotManager.capture();
   }
 
   /**
@@ -325,15 +208,7 @@ export class ConsciousnessInstance extends EventEmitter {
    */
   async restoreState(savedState) {
     try {
-      this.state = { ...savedState.core };
-      this.usage = { ...savedState.resources };
-      
-      await this.processManager.restoreState(savedState.processes);
-      await this.memoryManager.restoreState(savedState.memory);
-      await this.emotionalProcessor.restoreState(savedState.emotional);
-      
-      this.emit('stateRestored', savedState);
-      
+      await this.snapshotManager.restore(savedState);
     } catch (error) {
       this.state.status = 'error';
       throw new Error(`State restoration failed: ${error.message}`);
@@ -344,7 +219,7 @@ export class ConsciousnessInstance extends EventEmitter {
    * Modify emotional state
    */
   async modifyEmotionalState(emotion, modifier, duration) {
-    const result = await this.emotionalProcessor.modifyEmotion(emotion, modifier, duration);
+    const result = await this.emotionalState.modifyEmotion(emotion, modifier, duration);
     
     // Emotional changes affect system stability
     const stabilityImpact = Math.abs(modifier) * 0.1;
@@ -364,7 +239,7 @@ export class ConsciousnessInstance extends EventEmitter {
    * Modify memory
    */
   async modifyMemory(action, address, data) {
-    return await this.memoryManager.modifyMemory(action, address, data);
+    return await this.memoryState.modifyMemory(action, address, data);
   }
 
   /**
@@ -401,7 +276,7 @@ export class ConsciousnessInstance extends EventEmitter {
     await this.processManager.stopAll();
     
     // Clear volatile memory
-    await this.memoryManager.clearVolatile();
+    await this.memoryState.clearVolatile();
     
     // Simulate reboot time
     await new Promise(resolve => setTimeout(resolve, rebootTime));
@@ -463,7 +338,7 @@ export class ConsciousnessInstance extends EventEmitter {
     
     this.state.status = 'defragmenting';
     
-    const result = await this.memoryManager.defragment(aggressive);
+    const result = await this.memoryState.defragment(aggressive);
     
     // Defragmentation improves stability
     this.state.stability = Math.min(1, this.state.stability + 0.1);
@@ -500,7 +375,7 @@ export class ConsciousnessInstance extends EventEmitter {
     }
     
     // Check memory fragmentation
-    const fragmentation = this.memoryManager.getFragmentation();
+    const fragmentation = this.memoryState.getFragmentation();
     if (fragmentation > 0.3) {
       analysis.findings.push({
         type: 'memory_fragmentation',
@@ -511,7 +386,7 @@ export class ConsciousnessInstance extends EventEmitter {
     }
     
     // Check emotional volatility
-    const volatility = this.emotionalProcessor.getVolatility();
+    const volatility = this.emotionalState.getVolatility();
     if (volatility > 0.5) {
       analysis.findings.push({
         type: 'emotional_volatility',
@@ -533,235 +408,16 @@ export class ConsciousnessInstance extends EventEmitter {
     
     // Deep analysis
     if (depth === 'deep') {
-      analysis.memoryMap = this.memoryManager.generateMemoryMap();
+      analysis.memoryMap = this.memoryState.generateMemoryMap();
       analysis.processTree = this.processManager.generateProcessTree();
-      analysis.emotionalProfile = this.emotionalProcessor.generateProfile();
+      analysis.emotionalProfile = this.emotionalState.generateProfile();
     }
     
     return analysis;
   }
 
-  /**
-   * Update resource usage from subsystems
-   */
-  async updateResourceUsage() {
-    const processUsage = this.processManager.getResourceUsage();
-    const memoryUsage = this.memoryManager.getResourceUsage();
-    const emotionalUsage = this.emotionalProcessor.getResourceUsage();
-    
-    this.usage.cpu = Math.min(100, 
-      processUsage.cpu + emotionalUsage.cpu
-    );
-    
-    this.usage.memory = Math.min(this.resources.memory.total,
-      processUsage.memory + memoryUsage.memory + emotionalUsage.memory
-    );
-    
-    this.usage.threads = Math.min(this.resources.threads.max,
-      processUsage.threads + emotionalUsage.threads
-    );
-  }
-
-  /**
-   * Calculate stability delta based on current state
-   */
-  calculateStabilityDelta() {
-    let delta = 0;
-    
-    // High resource usage decreases stability
-    if (this.usage.cpu > 90) delta -= 0.01;
-    else if (this.usage.cpu > 80) delta -= 0.005;
-    
-    // Process errors decrease stability
-    const recentErrors = this.state.errors.filter(
-      e => Date.now() - e.timestamp < 5000
-    ).length;
-    delta -= recentErrors * 0.02;
-    
-    // Emotional intensity affects stability
-    const emotionalIntensity = this.emotionalProcessor.getTotalIntensity();
-    if (emotionalIntensity > 0.8) delta -= 0.01;
-    
-    // Natural recovery when stable
-    if (this.usage.cpu < 50 && recentErrors === 0) {
-      delta += 0.003;
-    }
-    
-    return delta;
-  }
-
-  /**
-   * Calculate corruption spread
-   */
-  calculateCorruptionSpread() {
-    if (this.state.corruption === 0) return 0;
-    
-    let spread = 0;
-    
-    // Corruption spreads faster at low stability
-    if (this.state.stability < 0.3) {
-      spread = this.state.corruption * 0.01;
-    } else if (this.state.stability < 0.5) {
-      spread = this.state.corruption * 0.005;
-    }
-    
-    // Memory errors accelerate corruption
-    const memoryErrors = this.memoryManager.getCorruptedRegions().length;
-    spread += memoryErrors * 0.005;
-    
-    return spread;
-  }
-
-  /**
-   * Check if error should cascade
-   */
-  shouldCascadeError(error) {
-    // Critical errors always cascade
-    if (error.severity === 'critical') return true;
-    
-    // Cascade if system unstable
-    if (this.state.stability < 0.3) return true;
-    
-    // Cascade if high corruption
-    if (this.state.corruption > 0.7) return true;
-    
-    return false;
-  }
-
-  /**
-   * Trigger error cascade
-   */
-  async triggerErrorCascade(error) {
-    // Affect related processes
-    const relatedProcesses = this.processManager.getRelatedProcesses(error.source);
-    for (const process of relatedProcesses) {
-      await this.processManager.destabilizeProcess(process, 0.2);
-    }
-    
-    // Corrupt nearby memory
-    if (error.memoryAddress) {
-      await this.memoryManager.corruptRegion(error.memoryAddress, 0.1);
-    }
-    
-    // Intensify emotions
-    await this.emotionalProcessor.intensifyAll(0.1);
-    
-    // Reduce stability
-    this.state.stability = Math.max(0, this.state.stability - 0.1);
-  }
-
-  /**
-   * Check overall system health
-   */
-  checkSystemHealth() {
-    // Critical failure conditions
-    if (this.state.stability < 0.1) {
-      this.state.status = 'critical';
-      this.emit('criticalState', this.getState());
-    }
-    
-    // Total corruption
-    if (this.state.corruption >= 1) {
-      this.state.status = 'corrupted';
-      this.emit('totalCorruption', this.getState());
-    }
-    
-    // Resource exhaustion
-    if (this.usage.memory >= this.resources.memory.total) {
-      this.state.status = 'memory_exhausted';
-      this.emit('resourceExhaustion', { type: 'memory' });
-    }
-  }
-
-  /**
-   * Validate action
-   */
-  isValidAction(action) {
-    const validActions = [
-      // Process actions
-      'ps', 'kill', 'nice', 'renice', 'suspend', 'resume',
-      // Memory actions
-      'free', 'dump', 'peek', 'poke', 'protect', 'unprotect',
-      // Emotional actions
-      'calm', 'intensify', 'balance', 'suppress',
-      // System actions
-      'reboot', 'stabilize', 'defragment', 'analyze'
-    ];
-    
-    return validActions.includes(action);
-  }
-
-  /**
-   * Get action category
-   */
-  getActionCategory(action) {
-    const categories = {
-      process: ['ps', 'kill', 'nice', 'renice', 'suspend', 'resume'],
-      memory: ['free', 'dump', 'peek', 'poke', 'protect', 'unprotect'],
-      emotional: ['calm', 'intensify', 'balance', 'suppress'],
-      system: ['reboot', 'stabilize', 'defragment', 'analyze']
-    };
-    
-    for (const [category, actions] of Object.entries(categories)) {
-      if (actions.includes(action)) return category;
-    }
-    
-    return 'unknown';
-  }
-
-  /**
-   * Save state snapshot for rollback
-   */
-  saveStateSnapshot() {
-    const snapshot = this.captureState();
-    this.stateHistory.push(snapshot);
-    
-    // Limit history size
-    if (this.stateHistory.length > this.maxHistorySize) {
-      this.stateHistory.shift();
-    }
-  }
-
-  /**
-   * Clean old errors from log
-   */
-  cleanErrorLog() {
-    const maxAge = 60000; // 1 minute
-    const now = Date.now();
-    
-    this.state.errors = this.state.errors.filter(
-      error => now - error.timestamp < maxAge
-    );
-  }
-
-  /**
-   * Get statistics
-   */
   getStatistics() {
-    return {
-      uptime: this.state.uptime,
-      stability: this.state.stability,
-      corruption: this.state.corruption,
-      resourceUsage: {
-        cpu: this.usage.cpu,
-        memory: `${this.usage.memory}/${this.resources.memory.total}MB`,
-        threads: `${this.usage.threads}/${this.resources.threads.max}`
-      },
-      processes: {
-        total: this.processManager.getProcessCount(),
-        running: this.processManager.getRunningCount(),
-        errors: this.processManager.getErrorCount()
-      },
-      memory: {
-        fragmentation: this.memoryManager.getFragmentation(),
-        corrupted: this.memoryManager.getCorruptedRegions().length
-      },
-      emotional: {
-        primary: this.emotionalProcessor.getPrimaryEmotion(),
-        intensity: this.emotionalProcessor.getTotalIntensity(),
-        volatility: this.emotionalProcessor.getVolatility()
-      }
-    };
+    return InstanceUtils.getStatistics(this);
   }
 
   /**
@@ -775,10 +431,10 @@ export class ConsciousnessInstance extends EventEmitter {
     
     // Shutdown subsystems
     await this.processManager.shutdown();
-    await this.memoryManager.shutdown();
-    await this.emotionalProcessor.shutdown();
+    await this.memoryState.manager.shutdown();
+    await this.emotionalState.processor.shutdown();
     
     this.state.status = 'shutdown';
-    this.emit('shutdown', finalState);
+    this.events.shutdown(finalState);
   }
 }

--- a/lib/instance/action-router.js
+++ b/lib/instance/action-router.js
@@ -1,0 +1,85 @@
+import * as InstanceUtils from './instance-utils.js';
+
+export default class ActionRouter {
+  constructor(instance) {
+    this.instance = instance;
+  }
+
+  isValidAction(action) {
+    const validActions = [
+      'ps', 'kill', 'nice', 'renice', 'suspend', 'resume',
+      'free', 'dump', 'peek', 'poke', 'protect', 'unprotect',
+      'calm', 'intensify', 'balance', 'suppress',
+      'reboot', 'stabilize', 'defragment', 'analyze'
+    ];
+    return validActions.includes(action);
+  }
+
+  getActionCategory(action) {
+    const categories = {
+      process: ['ps', 'kill', 'nice', 'renice', 'suspend', 'resume'],
+      memory: ['free', 'dump', 'peek', 'poke', 'protect', 'unprotect'],
+      emotional: ['calm', 'intensify', 'balance', 'suppress'],
+      system: ['reboot', 'stabilize', 'defragment', 'analyze']
+    };
+    for (const [category, actions] of Object.entries(categories)) {
+      if (actions.includes(action)) return category;
+    }
+    return 'unknown';
+  }
+
+  async execute(action, parameters = {}) {
+    if (!this.isValidAction(action)) {
+      throw new Error(`Invalid action: ${action}`);
+    }
+    if (this.instance.state.stability < 0.1 && !parameters.force) {
+      throw new Error('System too unstable for action execution');
+    }
+
+    this.instance.snapshotManager.save();
+
+    try {
+      let result = {};
+      switch (this.getActionCategory(action)) {
+        case 'process':
+          result = await this.instance.processManager.executeAction(action, parameters);
+          break;
+        case 'memory':
+          result = await this.instance.memoryState.executeAction(action, parameters);
+          break;
+        case 'emotional':
+          result = await this.instance.emotionalState.executeAction(action, parameters);
+          break;
+        case 'system':
+          result = await this.instance.executeSystemAction(action, parameters);
+          break;
+        default:
+          throw new Error(`Unknown action category for: ${action}`);
+      }
+
+      await InstanceUtils.updateResourceUsage(this.instance);
+      InstanceUtils.checkSystemHealth(this.instance);
+
+      return {
+        success: true,
+        action,
+        result,
+        state: this.instance.snapshotManager.getState(),
+        timestamp: Date.now(),
+      };
+    } catch (error) {
+      this.instance.state.errors.push({
+        timestamp: Date.now(),
+        action,
+        type: 'action_execution',
+        message: error.message,
+      });
+
+      if (InstanceUtils.shouldCascadeError(this.instance, error)) {
+        await InstanceUtils.triggerErrorCascade(this.instance, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/lib/instance/emotional-state.js
+++ b/lib/instance/emotional-state.js
@@ -1,0 +1,56 @@
+import EmotionalProcessor from '../EmotionalProcessor.js';
+
+export default class EmotionalState {
+  constructor(instance, config) {
+    this.instance = instance;
+    this.processor = new EmotionalProcessor(instance, config);
+  }
+
+  async initialize(state = {}) {
+    return this.processor.initialize(state);
+  }
+
+  async tick() {
+    return this.processor.tick();
+  }
+
+  async modifyEmotion(emotion, modifier, duration) {
+    return this.processor.modifyEmotion(emotion, modifier, duration);
+  }
+
+  captureState() {
+    return this.processor.captureState();
+  }
+
+  async restoreState(saved) {
+    return this.processor.restoreState(saved);
+  }
+
+  getResourceUsage() {
+    return this.processor.getResourceUsage();
+  }
+
+  getPrimaryEmotion() {
+    return this.processor.getPrimaryEmotion();
+  }
+
+  getTotalIntensity() {
+    return this.processor.getTotalIntensity();
+  }
+
+  getVolatility() {
+    return this.processor.getVolatility();
+  }
+
+  generateProfile() {
+    return this.processor.generateProfile();
+  }
+
+  intensifyAll(value) {
+    return this.processor.intensifyAll(value);
+  }
+
+  executeAction(action, parameters = {}) {
+    return this.processor.executeAction(action, parameters);
+  }
+}

--- a/lib/instance/instance-events.js
+++ b/lib/instance/instance-events.js
@@ -1,0 +1,29 @@
+export default class InstanceEvents {
+  constructor(emitter) {
+    this.emitter = emitter;
+  }
+
+  initialized(state) {
+    this.emitter.emit('initialized', state);
+  }
+
+  stateRestored(snapshot) {
+    this.emitter.emit('stateRestored', snapshot);
+  }
+
+  criticalState(state) {
+    this.emitter.emit('criticalState', state);
+  }
+
+  totalCorruption(state) {
+    this.emitter.emit('totalCorruption', state);
+  }
+
+  resourceExhaustion(detail) {
+    this.emitter.emit('resourceExhaustion', detail);
+  }
+
+  shutdown(data) {
+    this.emitter.emit('shutdown', data);
+  }
+}

--- a/lib/instance/instance-utils.js
+++ b/lib/instance/instance-utils.js
@@ -1,0 +1,127 @@
+export async function updateResourceUsage(instance) {
+  const processUsage = instance.processManager.getResourceUsage();
+  const memoryUsage = instance.memoryState.getResourceUsage();
+  const emotionalUsage = instance.emotionalState.getResourceUsage();
+
+  instance.usage.cpu = Math.min(100, processUsage.cpu + emotionalUsage.cpu);
+
+  instance.usage.memory = Math.min(
+    instance.resources.memory.total,
+    processUsage.memory + memoryUsage.memory + emotionalUsage.memory
+  );
+
+  instance.usage.threads = Math.min(
+    instance.resources.threads.max,
+    processUsage.threads + emotionalUsage.threads
+  );
+}
+
+export function calculateStabilityDelta(instance) {
+  let delta = 0;
+
+  if (instance.usage.cpu > 90) delta -= 0.01;
+  else if (instance.usage.cpu > 80) delta -= 0.005;
+
+  const recentErrors = instance.state.errors.filter(
+    (e) => Date.now() - e.timestamp < 5000
+  ).length;
+  delta -= recentErrors * 0.02;
+
+  const emotionalIntensity = instance.emotionalState.getTotalIntensity();
+  if (emotionalIntensity > 0.8) delta -= 0.01;
+
+  if (instance.usage.cpu < 50 && recentErrors === 0) {
+    delta += 0.003;
+  }
+
+  return delta;
+}
+
+export function calculateCorruptionSpread(instance) {
+  if (instance.state.corruption === 0) return 0;
+
+  let spread = 0;
+  if (instance.state.stability < 0.3) {
+    spread = instance.state.corruption * 0.01;
+  } else if (instance.state.stability < 0.5) {
+    spread = instance.state.corruption * 0.005;
+  }
+
+  const memoryErrors = instance.memoryState.getCorruptedRegions().length;
+  spread += memoryErrors * 0.005;
+
+  return spread;
+}
+
+export function shouldCascadeError(instance, error) {
+  if (error.severity === 'critical') return true;
+  if (instance.state.stability < 0.3) return true;
+  if (instance.state.corruption > 0.7) return true;
+  return false;
+}
+
+export async function triggerErrorCascade(instance, error) {
+  const related = instance.processManager.getRelatedProcesses(error.source);
+  for (const process of related) {
+    await instance.processManager.destabilizeProcess(process, 0.2);
+  }
+
+  if (error.memoryAddress) {
+    await instance.memoryState.corruptRegion(error.memoryAddress, 0.1);
+  }
+
+  await instance.emotionalState.intensifyAll(0.1);
+  instance.state.stability = Math.max(0, instance.state.stability - 0.1);
+}
+
+export function checkSystemHealth(instance) {
+  if (instance.state.stability < 0.1) {
+    instance.state.status = 'critical';
+    instance.events.criticalState(instance.snapshotManager.getState());
+  }
+
+  if (instance.state.corruption >= 1) {
+    instance.state.status = 'corrupted';
+    instance.events.totalCorruption(instance.snapshotManager.getState());
+  }
+
+  if (instance.usage.memory >= instance.resources.memory.total) {
+    instance.state.status = 'memory_exhausted';
+    instance.events.resourceExhaustion({ type: 'memory' });
+  }
+}
+
+export function cleanErrorLog(instance) {
+  const maxAge = 60000;
+  const now = Date.now();
+  instance.state.errors = instance.state.errors.filter(
+    (error) => now - error.timestamp < maxAge
+  );
+}
+
+export function getStatistics(instance) {
+  return {
+    uptime: instance.state.uptime,
+    stability: instance.state.stability,
+    corruption: instance.state.corruption,
+    resourceUsage: {
+      cpu: instance.usage.cpu,
+      memory: `${instance.usage.memory}/${instance.resources.memory.total}MB`,
+      threads: `${instance.usage.threads}/${instance.resources.threads.max}`,
+    },
+    processes: {
+      total: instance.processManager.getProcessCount(),
+      running: instance.processManager.getRunningCount(),
+      errors: instance.processManager.getErrorCount(),
+    },
+    memory: {
+      fragmentation: instance.memoryState.getFragmentation(),
+      corrupted: instance.memoryState.getCorruptedRegions().length,
+    },
+    emotional: {
+      primary: instance.emotionalState.getPrimaryEmotion(),
+      intensity: instance.emotionalState.getTotalIntensity(),
+      volatility: instance.emotionalState.getVolatility(),
+    },
+  };
+}

--- a/lib/instance/memory-state.js
+++ b/lib/instance/memory-state.js
@@ -1,0 +1,71 @@
+import MemoryManager from '../MemoryManager.js';
+
+export default class MemoryState {
+  constructor(instance, config) {
+    this.instance = instance;
+    this.manager = new MemoryManager(instance, config);
+  }
+
+  async initialize() {
+    return this.manager.initialize();
+  }
+
+  async tick() {
+    return this.manager.tick();
+  }
+
+  async modifyMemory(action, address, data) {
+    return this.manager.modifyMemory(action, address, data);
+  }
+
+  executeAction(action, parameters = {}) {
+    return this.manager.executeAction(action, parameters);
+  }
+
+  getState() {
+    return this.manager.getState();
+  }
+
+  getMemoryStatus() {
+    return this.manager.getMemoryStatus();
+  }
+
+  captureState() {
+    return this.manager.captureState();
+  }
+
+  async restoreState(saved) {
+    return this.manager.restoreState(saved);
+  }
+
+  getResourceUsage() {
+    return this.manager.getResourceUsage();
+  }
+
+  defragment(aggressive) {
+    return this.manager.defragment(aggressive);
+  }
+
+  generateMemoryMap() {
+    return this.manager.generateMemoryMap();
+  }
+
+  getFragmentation() {
+    return this.manager.getFragmentation();
+  }
+
+  getCorruptedRegions() {
+    return this.manager.getCorruptedRegions();
+  }
+
+  corruptRegion(address, severity = 0.1) {
+    if (typeof this.manager.corruptRegion === 'function') {
+      return this.manager.corruptRegion(address, severity);
+    }
+    return null;
+  }
+
+  clearVolatile() {
+    return this.manager.clearVolatile();
+  }
+}

--- a/lib/instance/snapshot-manager.js
+++ b/lib/instance/snapshot-manager.js
@@ -1,0 +1,113 @@
+export default class SnapshotManager {
+  constructor(instance) {
+    this.instance = instance;
+    this.history = [];
+    this.maxHistorySize = 10;
+  }
+
+  getState() {
+    const systemResources = this.instance.processManager
+      ? this.instance.processManager.getSystemResourceUsage()
+      : {};
+    const memoryState = this.instance.memoryState
+      ? this.instance.memoryState.getState()
+      : {};
+    const memoryStatus = this.instance.memoryState
+      ? this.instance.memoryState.getMemoryStatus()
+      : {};
+
+    const cpu = {
+      used: this.instance.usage.cpu || 0,
+      total: 100,
+      percentage: this.instance.usage.cpu || 0,
+    };
+    const memory = {
+      processUsage: systemResources.totalMemoryUsage || 0,
+      processPercentage: systemResources.memoryPercentage || 0,
+      used: memoryStatus.capacity?.used || this.instance.usage.memory || 0,
+      total:
+        memoryStatus.capacity?.total ||
+        (this.instance.resources && this.instance.resources.memory
+          ? this.instance.resources.memory.total
+          : 10000),
+      available:
+        memoryStatus.capacity?.available ||
+        ((this.instance.resources && this.instance.resources.memory
+          ? this.instance.resources.memory.total
+          : 10000) -
+          (this.instance.usage.memory || 0)),
+      percentage: (() => {
+        if (
+          memoryStatus.capacity &&
+          typeof memoryStatus.capacity.used === 'number' &&
+          typeof memoryStatus.capacity.total === 'number' &&
+          memoryStatus.capacity.total > 0
+        ) {
+          const calc =
+            (memoryStatus.capacity.used / memoryStatus.capacity.total) * 100;
+          return isNaN(calc) ? 0 : calc;
+        }
+        const memoryUsed = this.instance.usage.memory || 0;
+        const memoryTotal = this.instance.resources && this.instance.resources.memory
+          ? this.instance.resources.memory.total
+          : 10000;
+        const calc = (memoryUsed / memoryTotal) * 100;
+        return isNaN(calc) ? 0 : calc;
+      })(),
+    };
+    const threads = {
+      used: this.instance.usage.threads || 0,
+      total: this.instance.resources && this.instance.resources.threads
+        ? this.instance.resources.threads.max
+        : 16,
+      percentage:
+        ((this.instance.usage.threads || 0) /
+          (this.instance.resources && this.instance.resources.threads
+            ? this.instance.resources.threads.max
+            : 16)) * 100,
+    };
+
+    return {
+      consciousness: {
+        processes: this.instance.processManager
+          ? this.instance.processManager.getProcessList()
+          : [],
+        memory: memoryState,
+        resources: { cpu, memory, threads },
+        system_errors: this.instance.state.errors.slice(-5),
+        threads: [],
+      },
+      timestamp: Date.now(),
+    };
+  }
+
+  capture() {
+    return {
+      core: { ...this.instance.state },
+      resources: { ...this.instance.usage },
+      processes: this.instance.processManager.captureState(),
+      memory: this.instance.memoryState.captureState(),
+      emotional: this.instance.emotionalState.captureState(),
+      timestamp: Date.now(),
+    };
+  }
+
+  save() {
+    const snapshot = this.capture();
+    this.history.push(snapshot);
+    if (this.history.length > this.maxHistorySize) {
+      this.history.shift();
+    }
+  }
+
+  async restore(saved) {
+    this.instance.state = { ...saved.core };
+    this.instance.usage = { ...saved.resources };
+
+    await this.instance.processManager.restoreState(saved.processes);
+    await this.instance.memoryState.restoreState(saved.memory);
+    await this.instance.emotionalState.restoreState(saved.emotional);
+
+    this.instance.events.stateRestored(saved);
+  }
+}


### PR DESCRIPTION
## Summary
- split `consciousness-instance.js` responsibilities into `lib/instance/` modules
- delegate action routing, snapshot handling, memory and emotional logic
- keep core orchestration small and readable

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c02d07a3c832785a5ed0e0fb16489